### PR TITLE
Fix schema links for page resources

### DIFF
--- a/qhana_plugin_registry/api/models/generators/constants.py
+++ b/qhana_plugin_registry/api/models/generators/constants.py
@@ -106,11 +106,6 @@ SEED_EXTRA_LINK_RELATIONS = tuple()
 PLUGIN_EXTRA_LINK_RELATIONS = tuple()
 
 
-# schemas ######################################################################
-
-PAGE_SCHEMA = "PageApiObject"
-
-
 # endpoints ####################################################################
 
 API_SPEC_RESOURCE = "api-docs.openapi_json"

--- a/qhana_plugin_registry/api/models/generators/env.py
+++ b/qhana_plugin_registry/api/models/generators/env.py
@@ -24,14 +24,13 @@ from .constants import (
     CREATE_REL,
     DELETE_REL,
     NAV_REL,
-    PAGE_SCHEMA,
     POST_REL,
     ROOT_RESOURCE_DUMMY,
     ENV_ID_KEY,
     UP_REL,
 )
 from .type_map import TYPE_TO_METADATA
-from ..base_models import ApiLink, ApiResponse
+from ..base_models import ApiLink, ApiResponse, CursorPageSchema
 from ..request_helpers import (
     ApiObjectGenerator,
     ApiResponseGenerator,
@@ -72,7 +71,7 @@ class EnvCollectionLinkGenerator(LinkGenerator, resource_type=Env, page=True):
             rel=(COLLECTION_REL,),
             resource_type=meta.rel_type,
             resource_key=KeyGenerator.generate_key(resource, query_params=query_params),
-            schema=f"{url_for(API_SPEC_RESOURCE, _external=True)}#/components/schemas/{PAGE_SCHEMA}",
+            schema=f"{url_for(API_SPEC_RESOURCE, _external=True)}#/components/schemas/{CursorPageSchema.schema_name()}",
         )
 
 

--- a/qhana_plugin_registry/api/models/generators/plugins.py
+++ b/qhana_plugin_registry/api/models/generators/plugins.py
@@ -25,13 +25,12 @@ from .constants import (
     ITEM_COUNT_QUERY_KEY,
     NAV_REL,
     PAGE_REL,
-    PAGE_SCHEMA,
     PLUGIN_ID_KEY,
     ROOT_RESOURCE_DUMMY,
     UP_REL,
 )
 from .type_map import TYPE_TO_METADATA
-from ..base_models import ApiLink, ApiResponse
+from ..base_models import ApiLink, ApiResponse, CursorPageSchema
 from ..plugins import EntryPoint, PluginData, InputDataMetadata, DataMetadata
 from ..request_helpers import (
     ApiObjectGenerator,
@@ -70,7 +69,7 @@ class PluginPageLinkGenerator(LinkGenerator, resource_type=RAMP, page=True):
             rel=(COLLECTION_REL, PAGE_REL),
             resource_type=meta.rel_type,
             resource_key=KeyGenerator.generate_key(resource, query_params=query_params),
-            schema=f"{url_for(API_SPEC_RESOURCE, _external=True)}#/components/schemas/{PAGE_SCHEMA}",
+            schema=f"{url_for(API_SPEC_RESOURCE, _external=True)}#/components/schemas/{CursorPageSchema.schema_name()}",
         )
 
 

--- a/qhana_plugin_registry/api/models/generators/seeds.py
+++ b/qhana_plugin_registry/api/models/generators/seeds.py
@@ -27,14 +27,13 @@ from .constants import (
     ITEM_COUNT_QUERY_KEY,
     NAV_REL,
     PAGE_REL,
-    PAGE_SCHEMA,
     POST_REL,
     ROOT_RESOURCE_DUMMY,
     SEED_ID_KEY,
     UP_REL,
 )
 from .type_map import TYPE_TO_METADATA
-from ..base_models import ApiLink, ApiResponse
+from ..base_models import ApiLink, ApiResponse, CursorPageSchema
 from ..request_helpers import (
     ApiObjectGenerator,
     ApiResponseGenerator,
@@ -73,7 +72,7 @@ class SeedPageLinkGenerator(LinkGenerator, resource_type=Seed, page=True):
             rel=(COLLECTION_REL, PAGE_REL),
             resource_type=meta.rel_type,
             resource_key=KeyGenerator.generate_key(resource, query_params=query_params),
-            schema=f"{url_for(API_SPEC_RESOURCE, _external=True)}#/components/schemas/{PAGE_SCHEMA}",
+            schema=f"{url_for(API_SPEC_RESOURCE, _external=True)}#/components/schemas/{CursorPageSchema.schema_name()}",
         )
 
 

--- a/qhana_plugin_registry/api/models/generators/services.py
+++ b/qhana_plugin_registry/api/models/generators/services.py
@@ -27,14 +27,13 @@ from .constants import (
     ITEM_COUNT_QUERY_KEY,
     NAV_REL,
     PAGE_REL,
-    PAGE_SCHEMA,
     POST_REL,
     ROOT_RESOURCE_DUMMY,
     SERVICE_ID_KEY,
     UP_REL,
 )
 from .type_map import TYPE_TO_METADATA
-from ..base_models import ApiLink, ApiResponse
+from ..base_models import ApiLink, ApiResponse, CursorPageSchema
 from ..request_helpers import (
     ApiObjectGenerator,
     ApiResponseGenerator,
@@ -73,7 +72,7 @@ class ServicePageLinkGenerator(LinkGenerator, resource_type=Service, page=True):
             rel=(COLLECTION_REL, PAGE_REL),
             resource_type=meta.rel_type,
             resource_key=KeyGenerator.generate_key(resource, query_params=query_params),
-            schema=f"{url_for(API_SPEC_RESOURCE, _external=True)}#/components/schemas/{PAGE_SCHEMA}",
+            schema=f"{url_for(API_SPEC_RESOURCE, _external=True)}#/components/schemas/{CursorPageSchema.schema_name()}",
         )
 
 

--- a/qhana_plugin_registry/api/models/generators/templates.py
+++ b/qhana_plugin_registry/api/models/generators/templates.py
@@ -28,7 +28,6 @@ from .constants import (
     ITEM_COUNT_QUERY_KEY,
     NAV_REL,
     PAGE_REL,
-    PAGE_SCHEMA,
     POST_REL,
     PUT_REL,
     ROOT_RESOURCE_DUMMY,
@@ -36,7 +35,7 @@ from .constants import (
     UP_REL,
 )
 from .type_map import TYPE_TO_METADATA
-from ..base_models import ApiLink, ApiResponse
+from ..base_models import ApiLink, ApiResponse, CursorPageSchema
 from ..request_helpers import (
     ApiObjectGenerator,
     ApiResponseGenerator,
@@ -77,7 +76,7 @@ class TemplatePageLinkGenerator(
             rel=(COLLECTION_REL, PAGE_REL),
             resource_type=meta.rel_type,
             resource_key=KeyGenerator.generate_key(resource, query_params=query_params),
-            schema=f"{url_for(API_SPEC_RESOURCE, _external=True)}#/components/schemas/{PAGE_SCHEMA}",
+            schema=f"{url_for(API_SPEC_RESOURCE, _external=True)}#/components/schemas/{CursorPageSchema.schema_name()}",
         )
 
 


### PR DESCRIPTION
This PR fixes the schema links for page resources and replaces the string constant with a function call to get the name of the schema. This avoids the need to manually adapt the string constant if the name of the schema gets changed in the future.