### PR TITLE
Reduce the number of endpoint constants

### DIFF
--- a/qhana_plugin_registry/__init__.py
+++ b/qhana_plugin_registry/__init__.py
@@ -29,7 +29,6 @@ from flask_cors import CORS
 from tomli import load as load_toml
 
 from . import api, babel, celery, db, licenses
-from .api.models.generators.type_map import populate_endpoints
 from .util.config import DebugConfig, ProductionConfig
 
 # change this to change tha flask app name and the config env var prefix
@@ -137,9 +136,6 @@ def create_app(test_config: Optional[Dict[str, Any]] = None):
         from .util.debug_routes import register_debug_routes
 
         register_debug_routes(app)
-
-    # populate endpoint attributes of the metadata
-    populate_endpoints()
 
     return app
 

--- a/qhana_plugin_registry/__init__.py
+++ b/qhana_plugin_registry/__init__.py
@@ -29,6 +29,7 @@ from flask_cors import CORS
 from tomli import load as load_toml
 
 from . import api, babel, celery, db, licenses
+from .api.models.generators.type_map import populate_endpoints
 from .util.config import DebugConfig, ProductionConfig
 
 # change this to change tha flask app name and the config env var prefix
@@ -136,6 +137,9 @@ def create_app(test_config: Optional[Dict[str, Any]] = None):
         from .util.debug_routes import register_debug_routes
 
         register_debug_routes(app)
+
+    # populate endpoint attributes of the metadata
+    populate_endpoints()
 
     return app
 

--- a/qhana_plugin_registry/api/__init__.py
+++ b/qhana_plugin_registry/api/__init__.py
@@ -17,6 +17,7 @@
 from flask import Flask
 
 from .blueprint import API, ROOT_ENDPOINT
+from .models.generators.type_map import populate_metadata
 from .plugins import PLUGINS_API
 from .env import ENV_API
 from .seeds import SEEDS_API
@@ -39,3 +40,5 @@ def register_root_api(app: Flask):
     API.register_blueprint(SEEDS_API)
     API.register_blueprint(SERVICES_API)
     API.register_blueprint(TEMPLATES_API)
+
+    populate_metadata()

--- a/qhana_plugin_registry/api/models/generators/constants.py
+++ b/qhana_plugin_registry/api/models/generators/constants.py
@@ -109,19 +109,3 @@ PLUGIN_EXTRA_LINK_RELATIONS = tuple()
 # endpoints ####################################################################
 
 API_SPEC_RESOURCE = "api-docs.openapi_json"
-ROOT_RESOURCE = "api-root.RootView"
-
-ENV_COLLECTION_RESOURCE = "api-env.EnvRootView"
-ENV_RESOURCE = "api-env.EnvView"
-
-SERVICE_PAGE_RESOURCE = "api-services.ServicesRootView"
-SERVICE_RESOURCE = "api-services.ServiceView"
-
-TEMPLATE_PAGE_RESOURCE = "api-templates.TemplatesRootView"
-TEMPLATE_RESOURCE = "api-templates.TemplateView"
-
-SEED_PAGE_RESOURCE = "api-seeds.SeedsRootView"
-SEED_RESOURCE = "api-seeds.SeedView"
-
-PLUGIN_PAGE_RESOURCE = "api-plugins.PluginsRootView"
-PLUGIN_RESOURCE = "api-plugins.PluginView"

--- a/qhana_plugin_registry/api/models/generators/root.py
+++ b/qhana_plugin_registry/api/models/generators/root.py
@@ -18,7 +18,7 @@ from typing import Dict, Iterable, Optional
 
 from flask import url_for
 
-from .constants import API_REL, API_SPEC_RESOURCE, NAV_REL
+from .constants import API_REL, API_SPEC_RESOURCE, NAV_REL, SEED_REL_TYPE, ENV_REL_TYPE, SERVICE_REL_TYPE
 from .type_map import TYPE_TO_METADATA
 from ..base_models import ApiLink, ApiResponse
 from ..request_helpers import (
@@ -60,7 +60,7 @@ class RootDataLinkGenerator(LinkGenerator, resource_type=RootDataRaw):
 
 
 class RootDataSeedsNavLinkGenerator(
-    LinkGenerator, resource_type=RootDataRaw, relation=TYPE_TO_METADATA[Seed].rel_type
+    LinkGenerator, resource_type=RootDataRaw, relation=SEED_REL_TYPE
 ):
     def generate_link(
         self, resource: RootDataRaw, *, query_params: Optional[Dict[str, str]] = None
@@ -72,7 +72,7 @@ class RootDataSeedsNavLinkGenerator(
 
 
 class RootDataEnvNavLinkGenerator(
-    LinkGenerator, resource_type=RootDataRaw, relation=TYPE_TO_METADATA[Env].rel_type
+    LinkGenerator, resource_type=RootDataRaw, relation=ENV_REL_TYPE
 ):
     def generate_link(
         self, resource: RootDataRaw, *, query_params: Optional[Dict[str, str]] = None
@@ -84,7 +84,7 @@ class RootDataEnvNavLinkGenerator(
 
 
 class RootDataServicesNavLinkGenerator(
-    LinkGenerator, resource_type=RootDataRaw, relation=TYPE_TO_METADATA[Service].rel_type
+    LinkGenerator, resource_type=RootDataRaw, relation=SERVICE_REL_TYPE
 ):
     def generate_link(
         self, resource: RootDataRaw, *, query_params: Optional[Dict[str, str]] = None

--- a/qhana_plugin_registry/api/models/generators/type_map.py
+++ b/qhana_plugin_registry/api/models/generators/type_map.py
@@ -19,87 +19,38 @@ from typing import Optional, Sequence, Type
 
 from marshmallow.base import SchemaABC
 
-from . import constants as c
-from ..plugins import PluginSchema
-from ..root import RootSchema
-from ..root_raw import RootDataRaw
-from ..seeds import SeedSchema
-from ..env import EnvSchema
-from ..service import ServiceSchema
-from ..templates import TemplateSchema
-from ....db.models.plugins import RAMP
-from ....db.models.seeds import Seed
-from ....db.models.env import Env
-from ....db.models.services import Service
-from ....db.models.templates import WorkspaceTemplate
-
 
 @dataclass()
 class ResourceMetadata:
     rel_type: str
     extra_link_rels: Sequence[str]
-    endpoint: Optional[str]
+    endpoint: str
     schema: Type[SchemaABC]
     schema_id: str
     collection_endpoint: Optional[str]
 
 
 TYPE_TO_METADATA = {
-    RootDataRaw: ResourceMetadata(
-        rel_type=c.ROOT_REL_TYPE,
-        extra_link_rels=c.ROOT_EXTRA_LINK_RELATIONS,
-        endpoint=None,
-        schema=RootSchema,
-        schema_id=RootSchema.schema_name(),
-        collection_endpoint=None,
-    ),
-    Env: ResourceMetadata(
-        rel_type=c.ENV_REL_TYPE,
-        extra_link_rels=c.ENV_EXTRA_LINK_RELATIONS,
-        endpoint=None,
-        schema=EnvSchema,
-        schema_id=EnvSchema.schema_name(),
-        collection_endpoint=None,
-    ),
-    Service: ResourceMetadata(
-        rel_type=c.SERVICE_REL_TYPE,
-        extra_link_rels=c.SERVICE_EXTRA_LINK_RELATIONS,
-        endpoint=None,
-        schema=ServiceSchema,
-        schema_id=ServiceSchema.schema_name(),
-        collection_endpoint=None,
-    ),
-    WorkspaceTemplate: ResourceMetadata(
-        rel_type=c.TEMPLATE_REL_TYPE,
-        extra_link_rels=c.TEMPLATE_EXTRA_LINK_RELATIONS,
-        endpoint=None,
-        schema=TemplateSchema,
-        schema_id=TemplateSchema.schema_name(),
-        collection_endpoint=None,
-    ),
-    Seed: ResourceMetadata(
-        rel_type=c.SEED_REL_TYPE,
-        extra_link_rels=c.SEED_EXTRA_LINK_RELATIONS,
-        endpoint=None,
-        schema=SeedSchema,
-        schema_id=SeedSchema.schema_name(),
-        collection_endpoint=None,
-    ),
-    RAMP: ResourceMetadata(
-        rel_type=c.PLUGIN_REL_TYPE,
-        extra_link_rels=c.PLUGIN_EXTRA_LINK_RELATIONS,
-        endpoint=None,
-        schema=PluginSchema,
-        schema_id=PluginSchema.schema_name(),
-        collection_endpoint=None,
-    ),
 }
 
 
-def populate_endpoints():
+def populate_metadata():
     """
     To prevent circular imports, the endpoints will be populated here and the necessary imports will be done here.
     """
+    from . import constants as c
+    from ..plugins import PluginSchema
+    from ..root import RootSchema
+    from ..root_raw import RootDataRaw
+    from ..seeds import SeedSchema
+    from ..env import EnvSchema
+    from ..service import ServiceSchema
+    from ..templates import TemplateSchema
+    from ....db.models.plugins import RAMP
+    from ....db.models.seeds import Seed
+    from ....db.models.env import Env
+    from ....db.models.services import Service
+    from ....db.models.templates import WorkspaceTemplate
     from ... import ROOT_ENDPOINT, ENV_API, SERVICES_API, TEMPLATES_API, SEEDS_API, PLUGINS_API
     from ...root import RootView
     from ...env.env import EnvView
@@ -113,19 +64,51 @@ def populate_endpoints():
     from ...plugins.plugin import PluginView
     from ...plugins.root import PluginsRootView
 
-    TYPE_TO_METADATA[RootDataRaw].endpoint = f"{ROOT_ENDPOINT.name}.{RootView.__name__}"
-
-    TYPE_TO_METADATA[Env].endpoint = f"{ENV_API.name}.{EnvView.__name__}"
-    TYPE_TO_METADATA[Env].collection_endpoint = f"{ENV_API.name}.{EnvRootView.__name__}"
-
-    TYPE_TO_METADATA[Service].endpoint = f"{SERVICES_API.name}.{ServiceView.__name__}"
-    TYPE_TO_METADATA[Service].collection_endpoint = f"{SERVICES_API.name}.{ServicesRootView.__name__}"
-
-    TYPE_TO_METADATA[WorkspaceTemplate].endpoint = f"{TEMPLATES_API.name}.{TemplateView.__name__}"
-    TYPE_TO_METADATA[WorkspaceTemplate].collection_endpoint = f"{TEMPLATES_API.name}.{TemplatesRootView.__name__}"
-
-    TYPE_TO_METADATA[Seed].endpoint = f"{SEEDS_API.name}.{SeedView.__name__}"
-    TYPE_TO_METADATA[Seed].collection_endpoint = f"{SEEDS_API.name}.{SeedsRootView.__name__}"
-
-    TYPE_TO_METADATA[RAMP].endpoint = f"{PLUGINS_API.name}.{PluginView.__name__}"
-    TYPE_TO_METADATA[RAMP].collection_endpoint = f"{PLUGINS_API.name}.{PluginsRootView.__name__}"
+    TYPE_TO_METADATA[RootDataRaw] = ResourceMetadata(
+        rel_type=c.ROOT_REL_TYPE,
+        extra_link_rels=c.ROOT_EXTRA_LINK_RELATIONS,
+        endpoint=f"{ROOT_ENDPOINT.name}.{RootView.__name__}",
+        schema=RootSchema,
+        schema_id=RootSchema.schema_name(),
+        collection_endpoint=None,
+    )
+    TYPE_TO_METADATA[Env] = ResourceMetadata(
+        rel_type=c.ENV_REL_TYPE,
+        extra_link_rels=c.ENV_EXTRA_LINK_RELATIONS,
+        endpoint=f"{ENV_API.name}.{EnvView.__name__}",
+        schema=EnvSchema,
+        schema_id=EnvSchema.schema_name(),
+        collection_endpoint=f"{ENV_API.name}.{EnvRootView.__name__}",
+    )
+    TYPE_TO_METADATA[Service] = ResourceMetadata(
+        rel_type=c.SERVICE_REL_TYPE,
+        extra_link_rels=c.SERVICE_EXTRA_LINK_RELATIONS,
+        endpoint=f"{SERVICES_API.name}.{ServiceView.__name__}",
+        schema=ServiceSchema,
+        schema_id=ServiceSchema.schema_name(),
+        collection_endpoint=f"{SERVICES_API.name}.{ServicesRootView.__name__}",
+    )
+    TYPE_TO_METADATA[WorkspaceTemplate] = ResourceMetadata(
+        rel_type=c.TEMPLATE_REL_TYPE,
+        extra_link_rels=c.TEMPLATE_EXTRA_LINK_RELATIONS,
+        endpoint=f"{TEMPLATES_API.name}.{TemplateView.__name__}",
+        schema=TemplateSchema,
+        schema_id=TemplateSchema.schema_name(),
+        collection_endpoint=f"{TEMPLATES_API.name}.{TemplatesRootView.__name__}",
+    )
+    TYPE_TO_METADATA[Seed] = ResourceMetadata(
+        rel_type=c.SEED_REL_TYPE,
+        extra_link_rels=c.SEED_EXTRA_LINK_RELATIONS,
+        endpoint=f"{SEEDS_API.name}.{SeedView.__name__}",
+        schema=SeedSchema,
+        schema_id=SeedSchema.schema_name(),
+        collection_endpoint=f"{SEEDS_API.name}.{SeedsRootView.__name__}",
+    )
+    TYPE_TO_METADATA[RAMP] = ResourceMetadata(
+        rel_type=c.PLUGIN_REL_TYPE,
+        extra_link_rels=c.PLUGIN_EXTRA_LINK_RELATIONS,
+        endpoint=f"{PLUGINS_API.name}.{PluginView.__name__}",
+        schema=PluginSchema,
+        schema_id=PluginSchema.schema_name(),
+        collection_endpoint=f"{PLUGINS_API.name}.{PluginsRootView.__name__}",
+    )

--- a/qhana_plugin_registry/api/models/generators/type_map.py
+++ b/qhana_plugin_registry/api/models/generators/type_map.py
@@ -34,11 +34,11 @@ from ....db.models.services import Service
 from ....db.models.templates import WorkspaceTemplate
 
 
-@dataclass(frozen=True)
+@dataclass()
 class ResourceMetadata:
     rel_type: str
     extra_link_rels: Sequence[str]
-    endpoint: str
+    endpoint: Optional[str]
     schema: Type[SchemaABC]
     schema_id: str
     collection_endpoint: Optional[str]
@@ -48,7 +48,7 @@ TYPE_TO_METADATA = {
     RootDataRaw: ResourceMetadata(
         rel_type=c.ROOT_REL_TYPE,
         extra_link_rels=c.ROOT_EXTRA_LINK_RELATIONS,
-        endpoint=c.ROOT_RESOURCE,
+        endpoint=None,
         schema=RootSchema,
         schema_id=RootSchema.schema_name(),
         collection_endpoint=None,
@@ -56,41 +56,76 @@ TYPE_TO_METADATA = {
     Env: ResourceMetadata(
         rel_type=c.ENV_REL_TYPE,
         extra_link_rels=c.ENV_EXTRA_LINK_RELATIONS,
-        endpoint=c.ENV_RESOURCE,
+        endpoint=None,
         schema=EnvSchema,
         schema_id=EnvSchema.schema_name(),
-        collection_endpoint=c.ENV_COLLECTION_RESOURCE,
+        collection_endpoint=None,
     ),
     Service: ResourceMetadata(
         rel_type=c.SERVICE_REL_TYPE,
         extra_link_rels=c.SERVICE_EXTRA_LINK_RELATIONS,
-        endpoint=c.SERVICE_RESOURCE,
+        endpoint=None,
         schema=ServiceSchema,
         schema_id=ServiceSchema.schema_name(),
-        collection_endpoint=c.SERVICE_PAGE_RESOURCE,
+        collection_endpoint=None,
     ),
     WorkspaceTemplate: ResourceMetadata(
         rel_type=c.TEMPLATE_REL_TYPE,
         extra_link_rels=c.TEMPLATE_EXTRA_LINK_RELATIONS,
-        endpoint=c.TEMPLATE_RESOURCE,
+        endpoint=None,
         schema=TemplateSchema,
         schema_id=TemplateSchema.schema_name(),
-        collection_endpoint=c.TEMPLATE_PAGE_RESOURCE,
+        collection_endpoint=None,
     ),
     Seed: ResourceMetadata(
         rel_type=c.SEED_REL_TYPE,
         extra_link_rels=c.SEED_EXTRA_LINK_RELATIONS,
-        endpoint=c.SEED_RESOURCE,
+        endpoint=None,
         schema=SeedSchema,
         schema_id=SeedSchema.schema_name(),
-        collection_endpoint=c.SEED_PAGE_RESOURCE,
+        collection_endpoint=None,
     ),
     RAMP: ResourceMetadata(
         rel_type=c.PLUGIN_REL_TYPE,
         extra_link_rels=c.PLUGIN_EXTRA_LINK_RELATIONS,
-        endpoint=c.PLUGIN_RESOURCE,
+        endpoint=None,
         schema=PluginSchema,
         schema_id=PluginSchema.schema_name(),
-        collection_endpoint=c.PLUGIN_PAGE_RESOURCE,
+        collection_endpoint=None,
     ),
 }
+
+
+def populate_endpoints():
+    """
+    To prevent circular imports, the endpoints will be populated here and the necessary imports will be done here.
+    """
+    from ... import ROOT_ENDPOINT, ENV_API, SERVICES_API, TEMPLATES_API, SEEDS_API, PLUGINS_API
+    from ...root import RootView
+    from ...env.env import EnvView
+    from ...env.root import EnvRootView
+    from ...services.service import ServiceView
+    from ...services.root import ServicesRootView
+    from ...templates.template import TemplateView
+    from ...templates.root import TemplatesRootView
+    from ...seeds.seed import SeedView
+    from ...seeds.root import SeedsRootView
+    from ...plugins.plugin import PluginView
+    from ...plugins.root import PluginsRootView
+
+    TYPE_TO_METADATA[RootDataRaw].endpoint = f"{ROOT_ENDPOINT.name}.{RootView.__name__}"
+
+    TYPE_TO_METADATA[Env].endpoint = f"{ENV_API.name}.{EnvView.__name__}"
+    TYPE_TO_METADATA[Env].collection_endpoint = f"{ENV_API.name}.{EnvRootView.__name__}"
+
+    TYPE_TO_METADATA[Service].endpoint = f"{SERVICES_API.name}.{ServiceView.__name__}"
+    TYPE_TO_METADATA[Service].collection_endpoint = f"{SERVICES_API.name}.{ServicesRootView.__name__}"
+
+    TYPE_TO_METADATA[WorkspaceTemplate].endpoint = f"{TEMPLATES_API.name}.{TemplateView.__name__}"
+    TYPE_TO_METADATA[WorkspaceTemplate].collection_endpoint = f"{TEMPLATES_API.name}.{TemplatesRootView.__name__}"
+
+    TYPE_TO_METADATA[Seed].endpoint = f"{SEEDS_API.name}.{SeedView.__name__}"
+    TYPE_TO_METADATA[Seed].collection_endpoint = f"{SEEDS_API.name}.{SeedsRootView.__name__}"
+
+    TYPE_TO_METADATA[RAMP].endpoint = f"{PLUGINS_API.name}.{PluginView.__name__}"
+    TYPE_TO_METADATA[RAMP].collection_endpoint = f"{PLUGINS_API.name}.{PluginsRootView.__name__}"


### PR DESCRIPTION
This PR reduces the number of endpoint constants by generating the endpoint URLs during runtime. This will make future refactoring easier. To prevent circular imports, I had to generate the URLs inside a function and import everything there.