### PR TITLE
Add config for scheme of generated URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ poetry run invoke worker --beat
 - add initial seeds and services with `INITIAL_PLUGIN_SEEDS` and `PRECONFIGURED_SERVICES`
 - add regex rewrite rules for urls with `URL_MAP_FROM_LOCALHOST` and `URL_MAP_TO_LOCALHOST`
 - The docker container includes a proxy to redirect requests to the host machine. To configure the ports that should be redirected set the environment variable `LOCALHOST_PROXY_PORTS` to e.g. `:1234 :2345`.
+- To force a specific scheme such as `https` for generated URLs, set `PREFERRED_URL_SCHEME` to the desired scheme 
 
 ### Trying out the Template
 

--- a/qhana_plugin_registry/__init__.py
+++ b/qhana_plugin_registry/__init__.py
@@ -76,9 +76,6 @@ def create_app(test_config: Optional[Dict[str, Any]] = None):
         # load config from file specified in env var
         config.from_envvar(f"{CONFIG_ENV_VAR_PREFIX}_SETTINGS", silent=True)
 
-        if "SERVER_NAME" in environ:
-            config["SERVER_NAME"] = environ["SERVER_NAME"]
-
         load_config_from_env(config)
     else:
         # load the test config if passed in

--- a/qhana_plugin_registry/api/models/generators/env.py
+++ b/qhana_plugin_registry/api/models/generators/env.py
@@ -16,7 +16,7 @@
 
 from typing import Dict, Iterable, Optional
 
-from flask import url_for
+from flask import url_for, current_app
 
 from .constants import (
     API_SPEC_RESOURCE,
@@ -68,12 +68,14 @@ class EnvCollectionLinkGenerator(LinkGenerator, resource_type=Env, page=True):
         if query_params is None:
             query_params = {}
 
+        scheme = current_app.config.get("PREFERRED_URL_SCHEME", "http")
+
         return ApiLink(
-            href=url_for(endpoint, **query_params, _external=True),
+            href=url_for(endpoint, **query_params, _external=True, _scheme=scheme),
             rel=(COLLECTION_REL,),
             resource_type=meta.rel_type,
             resource_key=KeyGenerator.generate_key(resource, query_params=query_params),
-            schema=f"{url_for(API_SPEC_RESOURCE, _external=True)}#/components/schemas/{CursorPageSchema.schema_name()}",
+            schema=f"{url_for(API_SPEC_RESOURCE, _external=True, _scheme=scheme)}#/components/schemas/{CursorPageSchema.schema_name()}",
         )
 
 
@@ -126,12 +128,14 @@ class EnvSelfLinkGenerator(LinkGenerator, resource_type=Env):
     ) -> Optional[ApiLink]:
         meta = TYPE_TO_METADATA[Env]
 
+        scheme = current_app.config.get("PREFERRED_URL_SCHEME", "http")
+
         return ApiLink(
-            href=url_for(meta.endpoint, env=str(resource.name), _external=True),
+            href=url_for(meta.endpoint, env=str(resource.name), _external=True, _scheme=scheme),
             rel=tuple(),
             resource_type=meta.rel_type,
             resource_key=KeyGenerator.generate_key(resource),
-            schema=f"{url_for(API_SPEC_RESOURCE, _external=True)}#/components/schemas/{meta.schema_id}",
+            schema=f"{url_for(API_SPEC_RESOURCE, _external=True, _scheme=scheme)}#/components/schemas/{meta.schema_id}",
             name=resource.name,
         )
 

--- a/qhana_plugin_registry/api/models/generators/env.py
+++ b/qhana_plugin_registry/api/models/generators/env.py
@@ -131,7 +131,9 @@ class EnvSelfLinkGenerator(LinkGenerator, resource_type=Env):
         scheme = current_app.config.get("PREFERRED_URL_SCHEME", "http")
 
         return ApiLink(
-            href=url_for(meta.endpoint, env=str(resource.name), _external=True, _scheme=scheme),
+            href=url_for(
+                meta.endpoint, env=str(resource.name), _external=True, _scheme=scheme
+            ),
             rel=tuple(),
             resource_type=meta.rel_type,
             resource_key=KeyGenerator.generate_key(resource),

--- a/qhana_plugin_registry/api/models/generators/plugins.py
+++ b/qhana_plugin_registry/api/models/generators/plugins.py
@@ -109,7 +109,9 @@ class PluginSelfLinkGenerator(LinkGenerator, resource_type=RAMP):
         scheme = current_app.config.get("PREFERRED_URL_SCHEME", "http")
 
         return ApiLink(
-            href=url_for(meta.endpoint, plugin_id=str(resource.id), _external=True, _scheme=scheme),
+            href=url_for(
+                meta.endpoint, plugin_id=str(resource.id), _external=True, _scheme=scheme
+            ),
             rel=tuple(),
             resource_type=meta.rel_type,
             resource_key=KeyGenerator.generate_key(resource),

--- a/qhana_plugin_registry/api/models/generators/plugins.py
+++ b/qhana_plugin_registry/api/models/generators/plugins.py
@@ -16,7 +16,7 @@
 
 from typing import Dict, Iterable, Optional
 
-from flask import url_for
+from flask import url_for, current_app
 
 from .constants import (
     API_SPEC_RESOURCE,
@@ -64,12 +64,14 @@ class PluginPageLinkGenerator(LinkGenerator, resource_type=RAMP, page=True):
         endpoint = meta.collection_endpoint
         assert endpoint is not None
 
+        scheme = current_app.config.get("PREFERRED_URL_SCHEME", "http")
+
         return ApiLink(
-            href=url_for(endpoint, **query_params, _external=True),
+            href=url_for(endpoint, **query_params, _external=True, _scheme=scheme),
             rel=(COLLECTION_REL, PAGE_REL),
             resource_type=meta.rel_type,
             resource_key=KeyGenerator.generate_key(resource, query_params=query_params),
-            schema=f"{url_for(API_SPEC_RESOURCE, _external=True)}#/components/schemas/{CursorPageSchema.schema_name()}",
+            schema=f"{url_for(API_SPEC_RESOURCE, _external=True, _scheme=scheme)}#/components/schemas/{CursorPageSchema.schema_name()}",
         )
 
 
@@ -104,12 +106,14 @@ class PluginSelfLinkGenerator(LinkGenerator, resource_type=RAMP):
     ) -> Optional[ApiLink]:
         meta = TYPE_TO_METADATA[RAMP]
 
+        scheme = current_app.config.get("PREFERRED_URL_SCHEME", "http")
+
         return ApiLink(
-            href=url_for(meta.endpoint, plugin_id=str(resource.id), _external=True),
+            href=url_for(meta.endpoint, plugin_id=str(resource.id), _external=True, _scheme=scheme),
             rel=tuple(),
             resource_type=meta.rel_type,
             resource_key=KeyGenerator.generate_key(resource),
-            schema=f"{url_for(API_SPEC_RESOURCE, _external=True)}#/components/schemas/{meta.schema_id}",
+            schema=f"{url_for(API_SPEC_RESOURCE, _external=True, _scheme=scheme)}#/components/schemas/{meta.schema_id}",
             name=f"{resource.name} ({resource.version})",
         )
 

--- a/qhana_plugin_registry/api/models/generators/recommendations.py
+++ b/qhana_plugin_registry/api/models/generators/recommendations.py
@@ -16,7 +16,7 @@
 
 from typing import Dict, Iterable, Optional
 
-from flask import url_for
+from flask import url_for, current_app
 
 from .constants import (
     API_SPEC_RESOURCE,
@@ -71,12 +71,14 @@ class RecommendationCollectionLinkGenerator(
         if query_params is None:
             query_params = {}
 
+        scheme = current_app.config.get("PREFERRED_URL_SCHEME", "http")
+
         return ApiLink(
-            href=url_for(endpoint, **query_params, _external=True),
+            href=url_for(endpoint, **query_params, _external=True, _scheme=scheme),
             rel=(COLLECTION_REL,),
             resource_type=meta.rel_type,
             resource_key=KeyGenerator.generate_key(resource, query_params=query_params),
-            schema=f"{url_for(API_SPEC_RESOURCE, _external=True)}#/components/schemas/{RecommendationCollectionSchema.schema_name()}",
+            schema=f"{url_for(API_SPEC_RESOURCE, _external=True, _scheme=scheme)}#/components/schemas/{RecommendationCollectionSchema.schema_name()}",
         )
 
 

--- a/qhana_plugin_registry/api/models/generators/root.py
+++ b/qhana_plugin_registry/api/models/generators/root.py
@@ -16,7 +16,7 @@
 
 from typing import Dict, Iterable, Optional
 
-from flask import url_for
+from flask import url_for, current_app
 
 from .constants import (
     API_REL,
@@ -62,12 +62,14 @@ class RootDataLinkGenerator(LinkGenerator, resource_type=RootDataRaw):
     ) -> Optional[ApiLink]:
         meta = TYPE_TO_METADATA[RootDataRaw]
 
+        scheme = current_app.config.get("PREFERRED_URL_SCHEME", "http")
+
         return ApiLink(
-            href=url_for(meta.endpoint, _external=True),
+            href=url_for(meta.endpoint, _external=True, _scheme=scheme),
             rel=tuple(),
             resource_type=meta.rel_type,
             resource_key=KeyGenerator.generate_key(resource, query_params=query_params),
-            schema=url_for(API_SPEC_RESOURCE, _external=True)
+            schema=url_for(API_SPEC_RESOURCE, _external=True, _scheme=scheme)
             + f"#/components/schemas/{meta.schema_id}",
         )
 

--- a/qhana_plugin_registry/api/models/generators/seeds.py
+++ b/qhana_plugin_registry/api/models/generators/seeds.py
@@ -124,7 +124,9 @@ class SeedSelfLinkGenerator(LinkGenerator, resource_type=Seed):
         scheme = current_app.config.get("PREFERRED_URL_SCHEME", "http")
 
         return ApiLink(
-            href=url_for(meta.endpoint, seed_id=str(resource.id), _external=True, _scheme=scheme),
+            href=url_for(
+                meta.endpoint, seed_id=str(resource.id), _external=True, _scheme=scheme
+            ),
             rel=tuple(),
             resource_type=meta.rel_type,
             resource_key=KeyGenerator.generate_key(resource),

--- a/qhana_plugin_registry/api/models/generators/seeds.py
+++ b/qhana_plugin_registry/api/models/generators/seeds.py
@@ -16,7 +16,7 @@
 
 from typing import Dict, Iterable, Optional
 
-from flask import url_for
+from flask import url_for, current_app
 
 from .constants import (
     API_SPEC_RESOURCE,
@@ -67,12 +67,14 @@ class SeedPageLinkGenerator(LinkGenerator, resource_type=Seed, page=True):
         endpoint = meta.collection_endpoint
         assert endpoint is not None
 
+        scheme = current_app.config.get("PREFERRED_URL_SCHEME", "http")
+
         return ApiLink(
-            href=url_for(endpoint, **query_params, _external=True),
+            href=url_for(endpoint, **query_params, _external=True, _scheme=scheme),
             rel=(COLLECTION_REL, PAGE_REL),
             resource_type=meta.rel_type,
             resource_key=KeyGenerator.generate_key(resource, query_params=query_params),
-            schema=f"{url_for(API_SPEC_RESOURCE, _external=True)}#/components/schemas/{CursorPageSchema.schema_name()}",
+            schema=f"{url_for(API_SPEC_RESOURCE, _external=True, _scheme=scheme)}#/components/schemas/{CursorPageSchema.schema_name()}",
         )
 
 
@@ -119,12 +121,14 @@ class SeedSelfLinkGenerator(LinkGenerator, resource_type=Seed):
     ) -> Optional[ApiLink]:
         meta = TYPE_TO_METADATA[Seed]
 
+        scheme = current_app.config.get("PREFERRED_URL_SCHEME", "http")
+
         return ApiLink(
-            href=url_for(meta.endpoint, seed_id=str(resource.id), _external=True),
+            href=url_for(meta.endpoint, seed_id=str(resource.id), _external=True, _scheme=scheme),
             rel=tuple(),
             resource_type=meta.rel_type,
             resource_key=KeyGenerator.generate_key(resource),
-            schema=f"{url_for(API_SPEC_RESOURCE, _external=True)}#/components/schemas/{meta.schema_id}",
+            schema=f"{url_for(API_SPEC_RESOURCE, _external=True, _scheme=scheme)}#/components/schemas/{meta.schema_id}",
             name=resource.url,
         )
 

--- a/qhana_plugin_registry/api/models/generators/services.py
+++ b/qhana_plugin_registry/api/models/generators/services.py
@@ -127,7 +127,10 @@ class ServiceSelfLinkGenerator(LinkGenerator, resource_type=Service):
 
         return ApiLink(
             href=url_for(
-                meta.endpoint, service_id=str(resource.service_id), _external=True, _scheme=scheme
+                meta.endpoint,
+                service_id=str(resource.service_id),
+                _external=True,
+                _scheme=scheme,
             ),
             rel=tuple(),
             resource_type=meta.rel_type,

--- a/qhana_plugin_registry/api/models/generators/services.py
+++ b/qhana_plugin_registry/api/models/generators/services.py
@@ -16,7 +16,7 @@
 
 from typing import Dict, Iterable, Optional
 
-from flask import url_for
+from flask import url_for, current_app
 
 from .constants import (
     API_SPEC_RESOURCE,
@@ -69,12 +69,14 @@ class ServicePageLinkGenerator(LinkGenerator, resource_type=Service, page=True):
         endpoint = meta.collection_endpoint
         assert endpoint is not None
 
+        scheme = current_app.config.get("PREFERRED_URL_SCHEME", "http")
+
         return ApiLink(
-            href=url_for(endpoint, **query_params, _external=True),
+            href=url_for(endpoint, **query_params, _external=True, _scheme=scheme),
             rel=(COLLECTION_REL, PAGE_REL),
             resource_type=meta.rel_type,
             resource_key=KeyGenerator.generate_key(resource, query_params=query_params),
-            schema=f"{url_for(API_SPEC_RESOURCE, _external=True)}#/components/schemas/{CursorPageSchema.schema_name()}",
+            schema=f"{url_for(API_SPEC_RESOURCE, _external=True, _scheme=scheme)}#/components/schemas/{CursorPageSchema.schema_name()}",
         )
 
 
@@ -121,14 +123,16 @@ class ServiceSelfLinkGenerator(LinkGenerator, resource_type=Service):
     ) -> Optional[ApiLink]:
         meta = TYPE_TO_METADATA[Service]
 
+        scheme = current_app.config.get("PREFERRED_URL_SCHEME", "http")
+
         return ApiLink(
             href=url_for(
-                meta.endpoint, service_id=str(resource.service_id), _external=True
+                meta.endpoint, service_id=str(resource.service_id), _external=True, _scheme=scheme
             ),
             rel=tuple(),
             resource_type=meta.rel_type,
             resource_key=KeyGenerator.generate_key(resource),
-            schema=f"{url_for(API_SPEC_RESOURCE, _external=True)}#/components/schemas/{meta.schema_id}",
+            schema=f"{url_for(API_SPEC_RESOURCE, _external=True, _scheme=scheme)}#/components/schemas/{meta.schema_id}",
             name=resource.name,
         )
 

--- a/qhana_plugin_registry/api/models/generators/template_groups.py
+++ b/qhana_plugin_registry/api/models/generators/template_groups.py
@@ -16,7 +16,7 @@
 
 from typing import Dict, Iterable, Optional
 
-from flask import url_for
+from flask import url_for, current_app
 
 from .constants import (
     API_SPEC_RESOURCE,
@@ -67,17 +67,20 @@ class TemplateGroupLinkGenerator(LinkGenerator, resource_type=TemplateGroupRaw):
         else:
             query_params[TEMPLATE_GROUP_QUERY_KEY] = resource.location
 
+        scheme = current_app.config.get("PREFERRED_URL_SCHEME", "http")
+
         return ApiLink(
             href=url_for(
                 endpoint,
                 template_id=str(resource.template.id),
                 **query_params,
                 _external=True,
+                _scheme=scheme
             ),
             rel=(COLLECTION_REL,),
             resource_type=meta.rel_type,
             resource_key=KeyGenerator.generate_key(resource, query_params=query_params),
-            schema=f"{url_for(API_SPEC_RESOURCE, _external=True)}#/components/schemas/{TemplateGroupSchema.schema_name()}",
+            schema=f"{url_for(API_SPEC_RESOURCE, _external=True, _scheme=scheme)}#/components/schemas/{TemplateGroupSchema.schema_name()}",
             name=f"Tab Group: {resource.location}",
         )
 

--- a/qhana_plugin_registry/api/models/generators/template_groups.py
+++ b/qhana_plugin_registry/api/models/generators/template_groups.py
@@ -75,7 +75,7 @@ class TemplateGroupLinkGenerator(LinkGenerator, resource_type=TemplateGroupRaw):
                 template_id=str(resource.template.id),
                 **query_params,
                 _external=True,
-                _scheme=scheme
+                _scheme=scheme,
             ),
             rel=(COLLECTION_REL,),
             resource_type=meta.rel_type,

--- a/qhana_plugin_registry/api/models/generators/template_tabs.py
+++ b/qhana_plugin_registry/api/models/generators/template_tabs.py
@@ -86,7 +86,7 @@ class TemplateTabPageLinkGenerator(LinkGenerator, resource_type=TemplateTab, pag
                 template_id=str(resource.resource.id),
                 **query_params,
                 _external=True,
-                _scheme=scheme
+                _scheme=scheme,
             ),
             rel=(COLLECTION_REL,),
             resource_type=meta.rel_type,
@@ -158,7 +158,7 @@ class TemplateTabSelfLinkGenerator(LinkGenerator, resource_type=TemplateTab):
                 template_id=str(resource.template_id),
                 tab_id=str(resource.id),
                 _external=True,
-                _scheme=scheme
+                _scheme=scheme,
             ),
             rel=tuple(),
             resource_type=meta.rel_type,

--- a/qhana_plugin_registry/api/models/generators/template_tabs.py
+++ b/qhana_plugin_registry/api/models/generators/template_tabs.py
@@ -16,7 +16,7 @@
 
 from typing import Dict, Iterable, Optional
 
-from flask import url_for
+from flask import url_for, current_app
 
 from .constants import (
     API_SPEC_RESOURCE,
@@ -78,17 +78,20 @@ class TemplateTabPageLinkGenerator(LinkGenerator, resource_type=TemplateTab, pag
         endpoint = meta.collection_endpoint
         assert endpoint is not None
 
+        scheme = current_app.config.get("PREFERRED_URL_SCHEME", "http")
+
         return ApiLink(
             href=url_for(
                 endpoint,
                 template_id=str(resource.resource.id),
                 **query_params,
                 _external=True,
+                _scheme=scheme
             ),
             rel=(COLLECTION_REL,),
             resource_type=meta.rel_type,
             resource_key=KeyGenerator.generate_key(resource, query_params=query_params),
-            schema=f"{url_for(API_SPEC_RESOURCE, _external=True)}#/components/schemas/{CursorPageSchema.schema_name()}",
+            schema=f"{url_for(API_SPEC_RESOURCE, _external=True, _scheme=scheme)}#/components/schemas/{CursorPageSchema.schema_name()}",
         )
 
 
@@ -147,17 +150,20 @@ class TemplateTabSelfLinkGenerator(LinkGenerator, resource_type=TemplateTab):
     ) -> Optional[ApiLink]:
         meta = TYPE_TO_METADATA[TemplateTab]
 
+        scheme = current_app.config.get("PREFERRED_URL_SCHEME", "http")
+
         return ApiLink(
             href=url_for(
                 meta.endpoint,
                 template_id=str(resource.template_id),
                 tab_id=str(resource.id),
                 _external=True,
+                _scheme=scheme
             ),
             rel=tuple(),
             resource_type=meta.rel_type,
             resource_key=KeyGenerator.generate_key(resource),
-            schema=f"{url_for(API_SPEC_RESOURCE, _external=True)}#/components/schemas/{meta.schema_id}",
+            schema=f"{url_for(API_SPEC_RESOURCE, _external=True, _scheme=scheme)}#/components/schemas/{meta.schema_id}",
             name=resource.name,
         )
 

--- a/qhana_plugin_registry/api/models/generators/templates.py
+++ b/qhana_plugin_registry/api/models/generators/templates.py
@@ -16,7 +16,7 @@
 
 from typing import Dict, Iterable, Optional, Set
 
-from flask import url_for
+from flask import url_for, current_app
 
 from .constants import (
     API_SPEC_RESOURCE,
@@ -71,12 +71,14 @@ class TemplatePageLinkGenerator(LinkGenerator, resource_type=UiTemplate, page=Tr
         endpoint = meta.collection_endpoint
         assert endpoint is not None
 
+        scheme = current_app.config.get("PREFERRED_URL_SCHEME", "http")
+
         return ApiLink(
-            href=url_for(endpoint, **query_params, _external=True),
+            href=url_for(endpoint, **query_params, _external=True, _scheme=scheme),
             rel=(COLLECTION_REL, PAGE_REL),
             resource_type=meta.rel_type,
             resource_key=KeyGenerator.generate_key(resource, query_params=query_params),
-            schema=f"{url_for(API_SPEC_RESOURCE, _external=True)}#/components/schemas/{CursorPageSchema.schema_name()}",
+            schema=f"{url_for(API_SPEC_RESOURCE, _external=True, _scheme=scheme)}#/components/schemas/{CursorPageSchema.schema_name()}",
         )
 
 
@@ -126,12 +128,14 @@ class TemplateSelfLinkGenerator(LinkGenerator, resource_type=UiTemplate):
     ) -> Optional[ApiLink]:
         meta = TYPE_TO_METADATA[UiTemplate]
 
+        scheme = current_app.config.get("PREFERRED_URL_SCHEME", "http")
+
         return ApiLink(
-            href=url_for(meta.endpoint, template_id=str(resource.id), _external=True),
+            href=url_for(meta.endpoint, template_id=str(resource.id), _external=True, _scheme=scheme),
             rel=tuple(),
             resource_type=meta.rel_type,
             resource_key=KeyGenerator.generate_key(resource),
-            schema=f"{url_for(API_SPEC_RESOURCE, _external=True)}#/components/schemas/{meta.schema_id}",
+            schema=f"{url_for(API_SPEC_RESOURCE, _external=True, _scheme=scheme)}#/components/schemas/{meta.schema_id}",
             name=resource.name,
         )
 

--- a/qhana_plugin_registry/api/models/generators/templates.py
+++ b/qhana_plugin_registry/api/models/generators/templates.py
@@ -131,7 +131,12 @@ class TemplateSelfLinkGenerator(LinkGenerator, resource_type=UiTemplate):
         scheme = current_app.config.get("PREFERRED_URL_SCHEME", "http")
 
         return ApiLink(
-            href=url_for(meta.endpoint, template_id=str(resource.id), _external=True, _scheme=scheme),
+            href=url_for(
+                meta.endpoint,
+                template_id=str(resource.id),
+                _external=True,
+                _scheme=scheme,
+            ),
             rel=tuple(),
             resource_type=meta.rel_type,
             resource_key=KeyGenerator.generate_key(resource),

--- a/qhana_plugin_registry/util/config/from_env.py
+++ b/qhana_plugin_registry/util/config/from_env.py
@@ -20,6 +20,7 @@ def load_config_from_env(config: Config):
     _load_preconfigured_values(config)
     _load_url_rewrite_rules(config, "URL_MAP_FROM_LOCALHOST")
     _load_url_rewrite_rules(config, "URL_MAP_TO_LOCALHOST")
+    _load_flask_config_from_env(config)
 
 
 def _load_database_uri_from_env(config: Config):
@@ -128,3 +129,8 @@ def _load_url_rewrite_rules(config: Config, key: str):
 
         if len(config[key]) != len(url_map):
             pass  # TODO some rewrite rules were dismissed as invalid!
+
+
+def _load_flask_config_from_env(config: Config):
+    if "SERVER_NAME" in environ:
+        config["SERVER_NAME"] = environ["SERVER_NAME"]

--- a/qhana_plugin_registry/util/config/from_env.py
+++ b/qhana_plugin_registry/util/config/from_env.py
@@ -137,4 +137,3 @@ def _load_flask_config_from_env(config: Config):
 
     if "PREFERRED_URL_SCHEME" in environ:
         config["PREFERRED_URL_SCHEME"] = environ["PREFERRED_URL_SCHEME"]
-

--- a/qhana_plugin_registry/util/config/from_env.py
+++ b/qhana_plugin_registry/util/config/from_env.py
@@ -134,3 +134,7 @@ def _load_url_rewrite_rules(config: Config, key: str):
 def _load_flask_config_from_env(config: Config):
     if "SERVER_NAME" in environ:
         config["SERVER_NAME"] = environ["SERVER_NAME"]
+
+    if "PREFERRED_URL_SCHEME" in environ:
+        config["PREFERRED_URL_SCHEME"] = environ["PREFERRED_URL_SCHEME"]
+


### PR DESCRIPTION
This PR adds the env var `PREFERRED_URL_SCHEME` which can be used to set the scheme of generated URLs. Setting this to `https` fixes an "mixed content error" when using the QHAna-UI in Chrome with `https`, because the generated URLs from the registry always contained `http` URLs.