### PR TITLE
Add env var to configure reverse proxy fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ poetry run invoke worker --beat
 - add initial seeds and services with `INITIAL_PLUGIN_SEEDS` and `PRECONFIGURED_SERVICES`
 - add regex rewrite rules for urls with `URL_MAP_FROM_LOCALHOST` and `URL_MAP_TO_LOCALHOST`
 - The docker container includes a proxy to redirect requests to the host machine. To configure the ports that should be redirected set the environment variable `LOCALHOST_PROXY_PORTS` to e.g. `:1234 :2345`.
-- if it runs behind a reverse proxy, set `REVERSE_PROXY_COUNT` to 1
+- if it runs behind a reverse proxy, set `REVERSE_PROXY_COUNT` to the number of trusted reverse proxies (e.g. 1)
 
 ### Trying out the Template
 

--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ poetry run invoke worker --beat
 - add initial seeds and services with `INITIAL_PLUGIN_SEEDS` and `PRECONFIGURED_SERVICES`
 - add regex rewrite rules for urls with `URL_MAP_FROM_LOCALHOST` and `URL_MAP_TO_LOCALHOST`
 - The docker container includes a proxy to redirect requests to the host machine. To configure the ports that should be redirected set the environment variable `LOCALHOST_PROXY_PORTS` to e.g. `:1234 :2345`.
+- if it runs behind a reverse proxy, set `REVERSE_PROXY_COUNT` to 1
 
 ### Trying out the Template
 

--- a/qhana_plugin_registry/__init__.py
+++ b/qhana_plugin_registry/__init__.py
@@ -31,6 +31,7 @@ from tomli import load as load_toml
 from . import api, babel, celery, db, licenses
 from .util.config import DebugConfig, ProductionConfig
 from .util.config.from_env import load_config_from_env
+from .util.reverse_proxy_fix import apply_reverse_proxy_fix
 
 # change this to change tha flask app name and the config env var prefix
 # must not contain any spaces!
@@ -81,6 +82,7 @@ def create_app(test_config: Optional[Dict[str, Any]] = None):
 
         if "REVERSE_PROXY_COUNT" in environ:
             config["REVERSE_PROXY_COUNT"] = environ["REVERSE_PROXY_COUNT"]
+            apply_reverse_proxy_fix(app)
 
         load_config_from_env(config)
     else:

--- a/qhana_plugin_registry/__init__.py
+++ b/qhana_plugin_registry/__init__.py
@@ -81,7 +81,7 @@ def create_app(test_config: Optional[Dict[str, Any]] = None):
             config["SERVER_NAME"] = environ["SERVER_NAME"]
 
         if "REVERSE_PROXY_COUNT" in environ:
-            config["REVERSE_PROXY_COUNT"] = environ["REVERSE_PROXY_COUNT"]
+            config["REVERSE_PROXY_COUNT"] = int(environ["REVERSE_PROXY_COUNT"])
             apply_reverse_proxy_fix(app)
 
         load_config_from_env(config)

--- a/qhana_plugin_registry/__init__.py
+++ b/qhana_plugin_registry/__init__.py
@@ -79,6 +79,9 @@ def create_app(test_config: Optional[Dict[str, Any]] = None):
         if "SERVER_NAME" in environ:
             config["SERVER_NAME"] = environ["SERVER_NAME"]
 
+        if "REVERSE_PROXY_COUNT" in environ:
+            config["REVERSE_PROXY_COUNT"] = environ["REVERSE_PROXY_COUNT"]
+
         load_config_from_env(config)
     else:
         # load the test config if passed in


### PR DESCRIPTION
The env var `REVERSE_PROXY_COUNT` can now be used to activate the reverse proxy fix that is needed when the registry runs behind a reverse proxy.