### PR TITLE
use database-dependend collation for name field

### DIFF
--- a/qhana_plugin_registry/db/models/model_helpers.py
+++ b/qhana_plugin_registry/db/models/model_helpers.py
@@ -62,7 +62,17 @@ class NameDescriptionMixin:
         default="",
         metadata={
             "sa": DB.Column(
-                DB.Unicode, nullable=False, index=True, info={"collate": "NOCASE"}
+                DB.Unicode,
+                nullable=False,
+                index=True,
+                info={
+                    "collate": {
+                        "postgresql": "POSIX",
+                        "mysql": "utf8mb4_bin",
+                        "sqlite": "NOCASE",
+                        "mssql": "Latin1_General_CI_AS",
+                    }
+                },
             )
         },
     )

--- a/qhana_plugin_registry/db/pagination.py
+++ b/qhana_plugin_registry/db/pagination.py
@@ -88,7 +88,9 @@ def get_page_info(
         sort_column = sortables[col_name]
         if "collate" in sort_column.info:
             order_by_clauses.append(
-                sort_direction(sort_column.collate(sort_column.info["collate"][DB.engine.name]))
+                sort_direction(
+                    sort_column.collate(sort_column.info["collate"][DB.engine.name])
+                )
             )
         else:
             order_by_clauses.append(sort_direction(sort_column))

--- a/qhana_plugin_registry/db/pagination.py
+++ b/qhana_plugin_registry/db/pagination.py
@@ -88,7 +88,7 @@ def get_page_info(
         sort_column = sortables[col_name]
         if "collate" in sort_column.info:
             order_by_clauses.append(
-                sort_direction(sort_column.collate(sort_column.info["collate"]))
+                sort_direction(sort_column.collate(sort_column.info["collate"][DB.engine.name]))
             )
         else:
             order_by_clauses.append(sort_direction(sort_column))

--- a/qhana_plugin_registry/db/pagination.py
+++ b/qhana_plugin_registry/db/pagination.py
@@ -31,6 +31,7 @@ from sqlalchemy.orm.query import Query
 from sqlalchemy.sql import column, func, select
 from sqlalchemy.sql.expression import and_, asc, desc, or_, ColumnElement
 from sqlalchemy.sql.selectable import CTE
+from flask import current_app
 
 from .db import DB, MODEL
 from .models.model_helpers import IdMixin
@@ -86,13 +87,18 @@ def get_page_info(
         sort_direction: Any = desc if direction == "desc" else asc
 
         sort_column = sortables[col_name]
-        if "collate" in sort_column.info:
-            order_by_clauses.append(
-                sort_direction(
-                    sort_column.collate(sort_column.info["collate"][DB.engine.name])
+        collate_dict = sort_column.info.get("collate", None)
+        if isinstance(collate_dict, dict):
+            collate = collate_dict.get(DB.engine.name, None)
+            if collate:
+                order_by_clauses.append(sort_direction(sort_column.collate(collate)))
+            else:
+                current_app.logger.warning(
+                    f"Collate missing for engine {DB.engine.name}: {collate_dict}"
                 )
-            )
         else:
+            if collate_dict is not None:
+                current_app.logger.warning(f"Collate is not a dict: {collate_dict}")
             order_by_clauses.append(sort_direction(sort_column))
     row_numbers: Any = func.row_number().over(order_by=order_by_clauses)
 


### PR DESCRIPTION
Different databases require different collations for case-insensitivity. To support not only sqlite databases the `name` field now holds a dictionary containing the corresponding collations for postgresql, mysql, sqlite, and mssql databases.

https://github.com/UST-QuAntiL/qhana-plugin-registry/blob/aac35387799065e7a2e5180be9169b60aa53cc03/qhana_plugin_registry/db/models/model_helpers.py#L68-L75

Fixes #17 