### PR TITLE
Load templates from files

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ poetry run invoke worker --beat
 - add regex rewrite rules for urls with `URL_MAP_FROM_LOCALHOST` and `URL_MAP_TO_LOCALHOST`
 - The docker container includes a proxy to redirect requests to the host machine. To configure the ports that should be redirected set the environment variable `LOCALHOST_PROXY_PORTS` to e.g. `:1234 :2345`.
 - if it runs behind a reverse proxy, set `REVERSE_PROXY_COUNT` to the number of trusted reverse proxies (e.g. 1)
+- preconfigured UiTemplates are loaded from json files specified via `UI_TEMPLATE_PATHS` (`:` separated list of paths to files/folders)
 
 ### Trying out the Template
 

--- a/qhana_plugin_registry/__init__.py
+++ b/qhana_plugin_registry/__init__.py
@@ -156,7 +156,7 @@ def create_app(test_config: Optional[Dict[str, Any]] = None):
 
     # load ui templates from configured files
     with app.app_context():
-        load_ui_templates(app)
+        load_ui_templates()
 
     # allow cors requests everywhere (CONFIGURE THIS TO YOUR PROJECTS NEEDS!)
     CORS(app)

--- a/qhana_plugin_registry/__init__.py
+++ b/qhana_plugin_registry/__init__.py
@@ -32,6 +32,7 @@ from . import api, babel, celery, db, licenses
 from .util.config import DebugConfig, ProductionConfig
 from .util.config.from_env import load_config_from_env
 from .util.reverse_proxy_fix import apply_reverse_proxy_fix
+from .util.ui_templates import load_ui_templates
 
 # change this to change tha flask app name and the config env var prefix
 # must not contain any spaces!
@@ -83,6 +84,11 @@ def create_app(test_config: Optional[Dict[str, Any]] = None):
         if "REVERSE_PROXY_COUNT" in environ:
             config["REVERSE_PROXY_COUNT"] = int(environ["REVERSE_PROXY_COUNT"])
             apply_reverse_proxy_fix(app)
+
+        if "UI_TEMPLATE_PATHS" in environ:
+            config["UI_TEMPLATE_PATHS"] = [
+                path for path in environ["UI_TEMPLATE_PATHS"].split(":") if path
+            ]
 
         load_config_from_env(config)
     else:
@@ -147,6 +153,10 @@ def create_app(test_config: Optional[Dict[str, Any]] = None):
     db.register_db(app)
 
     api.register_root_api(app)
+
+    # load ui templates from configured files
+    with app.app_context():
+        load_ui_templates(app)
 
     # allow cors requests everywhere (CONFIGURE THIS TO YOUR PROJECTS NEEDS!)
     CORS(app)

--- a/qhana_plugin_registry/db/models/templates.py
+++ b/qhana_plugin_registry/db/models/templates.py
@@ -241,9 +241,8 @@ class TemplateTab(IdMixin, ExistsMixin, NameDescriptionMixin):
     def get_by_name(
         template: UiTemplate, name: str, location: Optional[str] = None
     ) -> "Optional[TemplateTab]":
-        q = (
-            select(TemplateTab)
-            .filter(TemplateTab.template == template, TemplateTab.name == name)
+        q = select(TemplateTab).filter(
+            TemplateTab.template == template, TemplateTab.name == name
         )
         if location is not None:
             q = q.filter(TemplateTab.location == location)

--- a/qhana_plugin_registry/db/models/templates.py
+++ b/qhana_plugin_registry/db/models/templates.py
@@ -21,7 +21,6 @@ from sqlalchemy.orm import relationship
 from sqlalchemy.sql import select
 from sqlalchemy.sql import sqltypes as sql
 from sqlalchemy.sql.schema import Column, ForeignKey
-from sqlalchemy.exc import MultipleResultsFound
 
 from .model_helpers import ExistsMixin, IdMixin, NameDescriptionMixin
 from .plugins import RAMP
@@ -78,11 +77,9 @@ class UiTemplate(IdMixin, NameDescriptionMixin, ExistsMixin):
 
     @classmethod
     def get_by_name(cls, name: str) -> "UiTemplate":
-        q = select(cls).filter(cls.name == name)
-        try:
-            found_template: UiTemplate = DB.session.execute(q).scalar_one_or_none()
-        except MultipleResultsFound:
-            found_template = DB.session.execute(q).first()[0]
+        # TODO: handle multiple results properly
+        q = select(cls).filter(cls.name == name).limit(1)
+        found_template: UiTemplate = DB.session.execute(q).scalar_one_or_none()
         return found_template
 
     @classmethod

--- a/qhana_plugin_registry/db/models/templates.py
+++ b/qhana_plugin_registry/db/models/templates.py
@@ -243,8 +243,7 @@ class TemplateTab(IdMixin, ExistsMixin, NameDescriptionMixin):
     ) -> "Optional[TemplateTab]":
         q = (
             select(TemplateTab)
-            .filter(TemplateTab.template == template)
-            .filter(TemplateTab.name == name)
+            .filter(TemplateTab.template == template, TemplateTab.name == name)
         )
         if location is not None:
             q = q.filter(TemplateTab.location == location)

--- a/qhana_plugin_registry/util/ui_templates.py
+++ b/qhana_plugin_registry/util/ui_templates.py
@@ -52,8 +52,7 @@ def _load_template_from_file(app: Flask, file: Union[str, Path]) -> None:
             tab["filter_string"] = json.dumps(tab.pop("filter"))
             new_tab = TemplateTab.get_or_create(template=template, **tab)
             template.tabs.append(new_tab)
-
-    DB.session.commit()
+        DB.session.commit()
     app.logger.info(f"Loaded template '{template.name}' from file '{file}'.")
 
 

--- a/qhana_plugin_registry/util/ui_templates.py
+++ b/qhana_plugin_registry/util/ui_templates.py
@@ -26,7 +26,7 @@ def _load_template_from_file(app: Flask, file: Union[str, Path]) -> None:
         return
 
     try:
-        with open(file, "r") as f:
+        with file.open("r") as f:
             template_json = load(f)
             app.logger.info(f"Loaded template from file '{file}'.")
     except Exception:

--- a/qhana_plugin_registry/util/ui_templates.py
+++ b/qhana_plugin_registry/util/ui_templates.py
@@ -1,0 +1,85 @@
+from pathlib import Path
+from typing import Union
+from flask import Flask
+from json import load
+
+from ..db.db import DB
+from ..db.models.templates import UiTemplate
+
+
+def _load_template_from_file(app: Flask, file: Union[str, Path]) -> None:
+    """Load a template from a file.
+
+    Args:
+        app (Flask): the app instance
+        file (Union[str, Path]): the file path
+    """
+    if isinstance(file, str):
+        file = Path(file)
+
+    file = file.resolve()
+
+    if not file.exists():
+        app.logger.info(
+            f"Tried to load template from file '{file}' but it does not exist."
+        )
+        return
+
+    try:
+        with open(file, "r") as f:
+            template_json = load(f)
+            app.logger.info(f"Loaded template from file '{file}'.")
+    except Exception:
+        app.logger.warning(
+            f"Tried to load template from file '{file}' but an error occurred.",
+            exc_info=True,
+        )
+        return
+
+    template = UiTemplate.get_or_create_from_json(template_json)
+    app.logger.info(f"Loaded template '{template.name}' from file '{file}'.")
+    DB.session.commit()
+
+
+def _load_templates_from_folder(app: Flask, folder: Union[str, Path]) -> None:
+    """Load templates from a folder.
+
+    Args:
+        app (Flask): the app instance
+        folder (Union[str, Path]): the folder path
+    """
+    if isinstance(folder, str):
+        folder = Path(folder)
+
+    folder = folder.resolve()
+
+    if not folder.exists():
+        app.logger.info(
+            f"Tried to load templates from folder '{folder}' but it does not exist."
+        )
+        return
+
+    files = folder.glob("*.json")
+    for file in files:
+        _load_template_from_file(app, file)
+
+
+def load_ui_templates(app: Flask) -> None:
+    """Load templates from the plugin folders.
+
+    Args:
+        app (Flask): the app instance
+    """
+
+    template_folders = app.config.get("UI_TEMPLATE_PATHS", [])
+
+    for folder in template_folders:
+        path = Path(folder)
+        if path.is_dir():
+            _load_templates_from_folder(app, path)
+        elif path.is_file():
+            _load_template_from_file(app, path)
+        else:
+            app.logger.warning(
+                f"Tried to load templates from '{path}' but it is neither a file nor a folder."
+            )

--- a/qhana_plugin_registry/util/ui_templates.py
+++ b/qhana_plugin_registry/util/ui_templates.py
@@ -1,16 +1,14 @@
 import json
 from pathlib import Path
 from typing import Optional, Union
-from flask import Flask
 from json import load
-
-from qhana_plugin_registry.tasks.plugin_filter import evaluate_plugin_filter
+from flask import current_app as app
 
 from ..db.db import DB
 from ..db.models.templates import TemplateTab, TemplateTag, UiTemplate
 
 
-def _load_template_from_file(app: Flask, file: Union[str, Path]) -> None:
+def _load_template_from_file(file: Union[str, Path]) -> None:
     """Load a template from a file.
 
     Args:
@@ -56,7 +54,7 @@ def _load_template_from_file(app: Flask, file: Union[str, Path]) -> None:
     app.logger.info(f"Loaded template '{template.name}' from file '{file}'.")
 
 
-def _load_templates_from_folder(app: Flask, folder: Union[str, Path]) -> None:
+def _load_templates_from_folder(folder: Union[str, Path]) -> None:
     """Load templates from a folder.
 
     Args:
@@ -76,10 +74,10 @@ def _load_templates_from_folder(app: Flask, folder: Union[str, Path]) -> None:
 
     files = folder.glob("*.json")
     for file in files:
-        _load_template_from_file(app, file)
+        _load_template_from_file(file)
 
 
-def load_ui_templates(app: Flask) -> None:
+def load_ui_templates() -> None:
     """Load templates from the plugin folders.
 
     Args:
@@ -91,9 +89,9 @@ def load_ui_templates(app: Flask) -> None:
     for folder in template_folders:
         path = Path(folder)
         if path.is_dir():
-            _load_templates_from_folder(app, path)
+            _load_templates_from_folder(path)
         elif path.is_file():
-            _load_template_from_file(app, path)
+            _load_template_from_file(path)
         else:
             app.logger.warning(
                 f"Tried to load templates from '{path}' but it is neither a file nor a folder."


### PR DESCRIPTION
Load ui-templates from JSON files on startup. Files/folders need to be set via the `UI_TEMPLATE_PATHS` environment variable. Templates are added if no template with the same name exists.

<details>
<summary>Example JSON file</summary>

```json
{
    "name": "test template",
    "description": "test template",
    "tags": [
        "test"
    ],
    "tabs": [
        {
            "name": "test tab",
            "description": "test tab",
            "sort_key": 0,
            "location": "workspace",
            "filter": {
                "or": [
                    {
                        "name": "hello-world"
                    },
                    {
                        "type": "dataloader"
                    }
                ]
            }
        },
        {
            "name": "test tab 2",
            "description": "test tab 2",
            "sort_key": 1,
            "location": "workspace",
            "filter": {
                "or": [
                    {
                        "name": "hello-world"
                    },
                    {
                        "type": "visualization"
                    }
                ]
            }
        }
    ]
}
```
</details>